### PR TITLE
minor changes to vignettes to make code style more consistent

### DIFF
--- a/vignettes/TK00_Time_Series_Coercion.Rmd
+++ b/vignettes/TK00_Time_Series_Coercion.Rmd
@@ -138,7 +138,8 @@ Since we used the `tk_ts()` during coercion, we can extract the original index i
 
 ```{r}
 # Can now retrieve the original date index
-timetk_index <- tk_index(ten_year_treasury_rate_ts_timetk, timetk_idx = TRUE)
+timetk_index <- ten_year_treasury_rate_ts_timetk %>%
+    tk_index(timetk_idx = TRUE)
 head(timetk_index)
 class(timetk_index)
 ```

--- a/vignettes/TK02_Making_A_Future_Time_Series_Index.Rmd
+++ b/vignettes/TK02_Making_A_Future_Time_Series_Index.Rmd
@@ -139,7 +139,7 @@ idx_test[!(idx_test %in% idx_future_wdays_and_months)]
 
 ### Type II Errors
 
-__Errorst that algorithm failed to remove__. These errors are the eaisest to manage because typically the analyst generally knows which days should be removed. These errors can be addressed with `skip_values` provided prediction length is manageable. 
+__Errors that algorithm failed to remove__. These errors are the eaisest to manage because typically the analyst generally knows which days should be removed. These errors can be addressed with `skip_values` provided prediction length is manageable. 
 
 ```{r}
 idx_future_wdays_and_months[!(idx_future_wdays_and_months %in% idx_test)]
@@ -177,8 +177,10 @@ The FB data from the FANG data set has missing dates that follow primarily a wee
 FB_tbl <- FANG %>%
     filter(symbol %in% "FB") 
 
-FB_train <- filter(FB_tbl, year(date) < 2016)
-FB_test  <- filter(FB_tbl, year(date) >= 2016)
+FB_train <- FB_tbl %>%
+    filter(year(date) < 2016)
+FB_test  <- FB_tbl %>%
+    filter(year(date) >= 2016)
 
 idx_train <- tk_index(FB_train)
 idx_test  <- tk_index(FB_test)

--- a/vignettes/TK03_Forecasting_Using_Time_Series_Signature.Rmd
+++ b/vignettes/TK03_Forecasting_Using_Time_Series_Signature.Rmd
@@ -194,16 +194,16 @@ The [forecast accuracy](https://www.otexts.org/fpp/2/5) can be evaluated on the 
 
 ```{r}
 # Calculating forecast error
-test_residuals <- pred_test$.resid
-pct_err <- test_residuals/pred_test$cnt * 100 # Percentage error
+error_tbl <- pred_test %>%
+  mutate(pct_err = .resid/cnt * 100) %>%
+  summarize(
+    me = mean(.resid, na.rm = TRUE),
+    rmse = mean(.resid^2, na.rm = TRUE)^0.5,
+    mae = mean(abs(.resid), na.rm = TRUE),
+    mape = mean(abs(pct_err), na.rm = TRUE),
+    mpe = mean(pct_err, na.rm = TRUE)
+  )
 
-me   <- mean(test_residuals, na.rm=TRUE)
-rmse <- mean(test_residuals^2, na.rm=TRUE)^0.5
-mae  <- mean(abs(test_residuals), na.rm=TRUE)
-mape <- mean(abs(pct_err), na.rm=TRUE)
-mpe  <- mean(pct_err, na.rm=TRUE)
-
-error_tbl <- tibble(me, rmse, mae, mape, mpe)
 error_tbl
 ```
 
@@ -311,7 +311,7 @@ A forecast is never perfect. We need prediction intervals to account for the var
 
 ```{r}
 # Calculate standard deviation of residuals
-test_resid_sd <- sd(test_residuals)
+test_resid_sd <- sd(pred_test$.resid)
 
 bikes_future <- bikes_future %>%
     mutate(


### PR DESCRIPTION
Let me start by saying thanks for the great packages! I was reading through the vignettes for `timetk` today and noticed that the way the model errors were calculated in the "Forecasting" vignette departed from your very "tidy" way of doing things. The biggest change of this very minor PR is changing this calculation to a "tidy" version of it, which gives the same results. The other changes I am proposing are mostly just things that seemed a little out of place with the overall code style of the vignettes. Plus one very minor typo.

I hope you don't mind me suggesting some edits!