### PR TITLE
Don't set timezone on Date

### DIFF
--- a/R/tk_index.R
+++ b/R/tk_index.R
@@ -121,7 +121,7 @@ tk_index.ts <- function(data, timetk_idx = FALSE, silent = FALSE) {
         # Set the timezone
         tzone <- attr(attr(data, "index"), "tzone")
         if (!is.null(tzone))
-            if (!(tclass[[1]] %in% c("yearmon", "yearqtr")))
+            if (!(tclass[[1]] %in% c("yearmon", "yearqtr", "Date")))
                 lubridate::tz(ret) <- tzone[[1]]
 
     }
@@ -207,7 +207,7 @@ tk_index.xts <- function(data, timetk_idx = FALSE, silent = FALSE) {
     # Set the timezone
     tzone <- xts::tzone(data)
     if (!is.null(tzone))
-        if (!(tclass[[1]] %in% c("yearmon", "yearqtr")))
+        if (!(tclass[[1]] %in% c("yearmon", "yearqtr", "Date")))
             lubridate::tz(ret) <- tzone[[1]]
 
     return(ret)

--- a/R/tk_make_timeseries.R
+++ b/R/tk_make_timeseries.R
@@ -231,7 +231,6 @@ predict_future_timeseries_daily <- function(idx, n_future, inspect_weekdays, ins
 
     date_sequence <- lubridate::as_datetime(numeric_sequence) %>%
         lubridate::as_date()
-    lubridate::tz(date_sequence) <- lubridate::tz(idx)
 
     # Create new_data data frame with future obs timeseries signature
     new_data <- date_sequence %>%
@@ -291,7 +290,6 @@ make_sequential_timeseries_irregular_freq <- function(idx, n_future, skip_values
         # Date
         date_sequence <- lubridate::as_datetime(numeric_sequence) %>%
             lubridate::as_date()
-        lubridate::tz(date_sequence) <- lubridate::tz(idx)
     } else {
         # Datetime
         date_sequence <- lubridate::as_datetime(numeric_sequence)
@@ -404,8 +402,6 @@ add_insert_values <- function(date_sequence, insert_values) {
                 sort() %>%
                 lubridate::as_datetime() %>%
                 lubridate::as_date()
-
-            lubridate::tz(ret) <- lubridate::tz(date_sequence)
 
         } else if (inherits(date_sequence, "POSIXt")) {
 


### PR DESCRIPTION
  Accommodate recent changes to lubridate::tz<- which now returns POSIXct when
  used Date objects.

Discovered through broken [revdeps](https://github.com/tidyverse/lubridate/blob/5783476102b024892b3b620914e303b174b41437/revdep/problems.md#timetk)