### PR TITLE
Check input before passing to readr::type_convert() to prevent warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ __Bug Fixes__
 
 - `plot_time_series_regression()`: Fixed an issue when lags are added to `.formula`. Pads lags with NA. 
 
+- `tk_tbl.zoo()`: Fix an issue when `readr::type_convert()` produces warning messages about not having character columns in inputs. #89
+
 # timetk 2.6.1
 
 __Improvements__

--- a/R/coersion-tk_tbl.R
+++ b/R/coersion-tk_tbl.R
@@ -107,7 +107,9 @@ tk_tbl.data.frame <- function(data, preserve_index = TRUE, rename_index = "index
                 tibble::rownames_to_column(var = rename_index) %>%
                 tibble::as_tibble(...)
 
-            ret <- suppressMessages(readr::type_convert(ret))
+            if (any(vapply(ret, is.character, logical(1)))) {
+                ret <- suppressMessages(readr::type_convert(ret))
+            }
 
         } else {
 
@@ -163,8 +165,9 @@ tk_tbl.zoo <- function(data, preserve_index = TRUE, rename_index = "index", time
 
             if (!is.null(rename_index)) colnames(ret)[[1]] <- rename_index
 
-            ret <- suppressMessages(readr::type_convert(ret))
-
+            if (any(vapply(ret, is.character, logical(1)))) {
+                ret <- suppressMessages(readr::type_convert(ret))
+            }
 
         } else {
 


### PR DESCRIPTION
All tests passed locally.

```
==> Sourcing R files in 'tests' directory

Registered S3 method overwritten by 'tune':
  method                   from   
  required_pkgs.model_spec parsnip
── Attaching packages ─────────────────────────────────────── tidyverse 1.3.1 ──
✓ ggplot2 3.3.5     ✓ purrr   0.3.4
✓ tibble  3.1.3     ✓ dplyr   1.0.7
✓ tidyr   1.1.3     ✓ stringr 1.4.0
✓ readr   2.0.0     ✓ forcats 0.5.1
── Conflicts ────────────────────────────────────────── tidyverse_conflicts() ──
x readr::edition_get()   masks testthat::edition_get()
x dplyr::filter()        masks stats::filter()
x purrr::is_null()       masks testthat::is_null()
x dplyr::lag()           masks stats::lag()
x readr::local_edition() masks testthat::local_edition()
x dplyr::matches()       masks tidyr::matches(), testthat::matches()
Loading required package: lubridate

Attaching package: ‘lubridate’

The following objects are masked from ‘package:base’:

    date, intersect, setdiff, union

Loading required package: PerformanceAnalytics
Loading required package: xts
Loading required package: zoo

Attaching package: ‘zoo’

The following objects are masked from ‘package:base’:

    as.Date, as.Date.numeric


Attaching package: ‘xts’

The following objects are masked from ‘package:dplyr’:

    first, last


Attaching package: ‘PerformanceAnalytics’

The following object is masked from ‘package:graphics’:

    legend

Loading required package: quantmod
Loading required package: TTR
Registered S3 method overwritten by 'quantmod':
  method            from
  as.zoo.data.frame zoo 
══ Need to Learn tidyquant? ════════════════════════════════════════════════════
Business Science offers a 1-hour course - Learning Lab #9: Performance Analysis & Portfolio Optimization with tidyquant!
</> Learn more at: https://university.business-science.io/p/learning-labs-pro </>

Attaching package: ‘timeDate’

The following objects are masked from ‘package:PerformanceAnalytics’:

    kurtosis, skewness

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 394 ]

Tests complete
```

This fixes #89 and by extension business-science/tidyquant#202.