### PR TITLE
dplyr 1.0.8

### DIFF
--- a/R/augment-tk_augment_differences.R
+++ b/R/augment-tk_augment_differences.R
@@ -64,7 +64,7 @@ tk_augment_differences <- function(.data,
     column_expr <- enquo(.value)
     if (rlang::quo_is_missing(column_expr)) stop(call. = FALSE, "tk_augment_differences(.value) is missing.")
     if (rlang::is_missing(.lags)) stop(call. = FALSE, "tk_augment_differences(.lags) is missing.")
-    if (rlang::is_missing(.differences)) stop(call. = FALSE, "tk_augment_differences(.differences) is missing.")
+    # if (rlang::is_missing(.differences)) stop(call. = FALSE, "tk_augment_differences(.differences) is missing.")
     if (!any(.names == "auto")) {
         if (length(.names) != length(.lags) * length(.differences)) {
             rlang::abort(".names must be a vector of length ", length(.lags) * length(.differences))


### PR DESCRIPTION
We're in the process of releasing `dplyr` 1.0.8 (which depends on dev `rlang` which we'll release soon as well) and `timetk` appears to fail against them, because of this example: 

```r
#' library(tidyverse)
#' library(timetk)
#'
#' m4_monthly %>%
#'     group_by(id) %>%
#'     tk_augment_differences(value, .lags = 1:20)
```

We see:

````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘timetk-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: tk_augment_differences
  > ### Title: Add many differenced columns to the data
  > ### Aliases: tk_augment_differences
  > 
  > ### ** Examples
  > 
  > library(tidyverse)
  ── Attaching packages ─────────────────────────────────────── tidyverse 1.3.1 ──
  ✔ ggplot2 3.3.5          ✔ purrr   0.3.4     
  ✔ tibble  3.1.6          ✔ dplyr   1.0.7.9000
  ✔ tidyr   1.1.4          ✔ stringr 1.4.0     
  ✔ readr   2.1.0          ✔ forcats 0.5.1     
  ── Conflicts ────────────────────────────────────────── tidyverse_conflicts() ──
  ✖ dplyr::filter() masks stats::filter()
  ✖ dplyr::lag()    masks stats::lag()
  > library(timetk)
  > 
  > m4_monthly %>%
  +     group_by(id) %>%
  +     tk_augment_differences(value, .lags = 1:20)
  Error: tk_augment_differences(.differences) is missing.
  Execution halted

> checking data for non-ASCII characters ... NOTE
    Note: found 2750 marked UTF-8 strings

1 error x | 0 warnings ✓ | 1 note x
````

This pull request hints in the direction of the issue. I'm not sure this error should remain, given that `.differences` has a default value. In that case, perhaps the example should be updated. 

This might be related to this change in `rlang::is_missing()` https://github.com/r-lib/rlang/issues/1106 . cc @lionel-

