### PR TITLE
data.table backend for tk_augment_lags #102

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,9 @@ Imports:
     tsfeatures,
     hms,
     assertthat,
-    generics
+    generics,
+    data.table,
+    tidytable
 Suggests:
     tidyquant,
     tidymodels,


### PR DESCRIPTION
Hi @mdancho84 ,

I just updated the `tk_augment_lag` and `tk_augment_lead` functions so they work with data.table and tidytable behind. I think that with the changes made, both functions should be much faster because they are practically already written with functions that call C code. As a good practice, I think I would try to change the rest of the functions little by little to try to introduce `tidytable` as much as possible because it already has a large number of supported functions (all map family, dplyr verbs, tidyr family...). I have been very impressed with this package really.

Regards,