### PR TITLE
Remove deprecated recipes::terms_select

### DIFF
--- a/R/recipes-step_box_cox.R
+++ b/R/recipes-step_box_cox.R
@@ -143,7 +143,7 @@ step_box_cox_new <-
 #' @export
 prep.step_box_cox <- function(x, training, info = NULL, ...) {
 
-    col_names <- terms_select(x$terms, info = info)
+    col_names <- recipes_eval_select(x$terms, data = training, info = info)
     recipes::check_type(training[, col_names])
 
     lambda_values <- training[, col_names] %>%

--- a/R/recipes-step_diff.R
+++ b/R/recipes-step_diff.R
@@ -140,7 +140,7 @@ prep.step_diff <- function(x, training, info = NULL, ...) {
         difference  = x$difference,
         log         = x$log,
         prefix      = x$prefix,
-        columns     = terms_select(x$terms, info = info),
+        columns     = recipes_eval_select(x$terms, data = training, info = info),
         skip        = x$skip,
         id          = x$id
     )

--- a/R/recipes-step_fourier.R
+++ b/R/recipes-step_fourier.R
@@ -190,7 +190,7 @@ step_fourier_new <-
 #' @export
 prep.step_fourier <- function(x, training, info = NULL, ...) {
 
-    col_names <- recipes::terms_select(x$terms, info = info)
+    col_names <- recipes::recipes_eval_select(x$terms, data = training, info = info)
 
     date_data <- info[info$variable %in% col_names, ]
 

--- a/R/recipes-step_holiday_signature.R
+++ b/R/recipes-step_holiday_signature.R
@@ -172,7 +172,7 @@ step_holiday_signature_new <-
 #' @export
 prep.step_holiday_signature <- function(x, training, info = NULL, ...) {
 
-    col_names <- recipes::terms_select(x$terms, info = info)
+    col_names <- recipes::recipes_eval_select(x$terms, data = training, info = info)
 
     date_data <- info[info$variable %in% col_names, ]
 

--- a/R/recipes-step_log_interval.R
+++ b/R/recipes-step_log_interval.R
@@ -146,7 +146,7 @@ step_log_interval_new <-
 #' @export
 prep.step_log_interval <- function(x, training, info = NULL, ...) {
 
-    col_names <- terms_select(x$terms, info = info)
+    col_names <- recipes_eval_select(x$terms, data = training, info = info)
     recipes::check_type(training[, col_names])
 
     limit_lower_trained <- training[, col_names] %>%

--- a/R/recipes-step_slidify.R
+++ b/R/recipes-step_slidify.R
@@ -213,7 +213,7 @@ step_slidify_new <-
 #' @export
 prep.step_slidify <- function(x, training, info = NULL, ...) {
 
-    col_names <- recipes::terms_select(x$terms, info = info)
+    col_names <- recipes::recipes_eval_select(x$terms, data = training, info = info)
 
     if (any(info$type[info$variable %in% col_names] != "numeric"))
         rlang::abort("The selected variables should be numeric")

--- a/R/recipes-step_slidify_augment.R
+++ b/R/recipes-step_slidify_augment.R
@@ -154,7 +154,7 @@ step_slidify_augment_new <-
 #' @export
 prep.step_slidify_augment <- function(x, training, info = NULL, ...) {
 
-    col_names <- recipes::terms_select(x$terms, info = info)
+    col_names <- recipes::recipes_eval_select(x$terms, data = training, info = info)
 
     if (any(info$type[info$variable %in% col_names] != "numeric"))
         rlang::abort("The selected variables should be numeric")

--- a/R/recipes-step_smooth.R
+++ b/R/recipes-step_smooth.R
@@ -220,7 +220,7 @@ step_smooth_new <-
 #' @export
 prep.step_smooth <- function(x, training, info = NULL, ...) {
 
-    col_names <- recipes::terms_select(x$terms, info = info)
+    col_names <- recipes::recipes_eval_select(x$terms, data = training, info = info)
 
     if (any(info$type[info$variable %in% col_names] != "numeric"))
         rlang::abort("The selected variables should be numeric")

--- a/R/recipes-step_timeseries_signature.R
+++ b/R/recipes-step_timeseries_signature.R
@@ -133,7 +133,7 @@ step_timeseries_signature_new <-
 #' @export
 prep.step_timeseries_signature <- function(x, training, info = NULL, ...) {
 
-    col_names <- recipes::terms_select(x$terms, info = info)
+    col_names <- recipes::recipes_eval_select(x$terms, data = training, info = info)
 
     date_data <- info[info$variable %in% col_names, ]
 

--- a/R/recipes-step_ts_clean.R
+++ b/R/recipes-step_ts_clean.R
@@ -134,7 +134,7 @@ step_ts_clean_new <-
 #' @export
 prep.step_ts_clean <- function(x, training, info = NULL, ...) {
 
-    col_names <- terms_select(x$terms, info = info)
+    col_names <- recipes_eval_select(x$terms, data = training, info = info)
     recipes::check_type(training[, col_names])
 
     # Lambda Calculation

--- a/R/recipes-step_ts_impute.R
+++ b/R/recipes-step_ts_impute.R
@@ -138,7 +138,7 @@ step_ts_impute_new <-
 #' @export
 prep.step_ts_impute <- function(x, training, info = NULL, ...) {
 
-    col_names <- terms_select(x$terms, info = info)
+    col_names <- recipes_eval_select(x$terms, data = training, info = info)
     recipes::check_type(training[, col_names])
 
     # Lambda Calculation

--- a/R/recipes-step_ts_pad.R
+++ b/R/recipes-step_ts_pad.R
@@ -165,7 +165,7 @@ step_ts_pad_new <-
 #' @export
 prep.step_ts_pad <- function(x, training, info = NULL, ...) {
 
-    col_names <- recipes::terms_select(x$terms, info = info)
+    col_names <- recipes::recipes_eval_select(x$terms, data = training, info = info)
 
     date_data <- info[info$variable %in% col_names, ]
 


### PR DESCRIPTION
Replaces the deprecated `recipes::terms_select` with `recipes::recipe_eval_select`. Will mean requiring recipes >= 0.1.17. `devtools::test()` ran fine with all tests passing. Fixes  #124 