### PR TITLE
Allow for lags to be non-numeric.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: timetk
 Type: Package
 Title: A Tool Kit for Working with Time Series in R
-Version: 2.8.2
+Version: 2.8.2.9000
 Authors@R: c(
     person("Matt", "Dancho", email = "mdancho@business-science.io", role = c("aut", "cre")),
     person("Davis", "Vaughan", email = "dvaughan@business-science.io", role = c("aut"))

--- a/R/vec-lag.R
+++ b/R/vec-lag.R
@@ -2,7 +2,7 @@
 #'
 #' `lag_vec()` applies a Lag Transformation.
 #'
-#' @param x A numeric vector to be lagged.
+#' @param x A vector to be lagged.
 #' @param lag Which lag (how far back) to be included in the differencing calculation.
 #'  Negative lags are leads.
 #'
@@ -63,7 +63,6 @@
 #' @export
 lag_vec <- function(x, lag = 1) {
     # Checks
-    if (!is.numeric(x)) rlang::abort("Non-numeric data detected. 'x' must be numeric.")
     if (length(lag) > 1) stop(call. = FALSE, "lag_vec(length(lag) > 1): Multiple lags detected. Use tk_augment_lags().")
 
     if(length(x) < lag) {


### PR DESCRIPTION
@mdancho84 I'd like timetk to allow for non-numeric lags like categorical data. For example, it would be nice to create holiday lead/lags. I like to apply lags outside of a tidymodels workflow so I'd like to create lags before doing things like dummy variables in a tidymodels workflow. 