### PR TITLE
Use lubridate::as_datetime in get_timeseries_signature_date function

### DIFF
--- a/R/get-tk_get_timeseries.R
+++ b/R/get-tk_get_timeseries.R
@@ -119,7 +119,7 @@ get_timeseries_signature_date <- function(idx) {
             mday      = lubridate::mday(index) %>% as.integer(),
             qday      = lubridate::qday(lubridate::as_date(index)) %>% as.integer(),
             yday      = lubridate::yday(index) %>% as.integer(),
-            mweek     = stringi::stri_datetime_fields(lubridate::as_date(index))$WeekOfMonth %>% as.integer(),
+            mweek     = stringi::stri_datetime_fields(lubridate::as_datetime(index))$WeekOfMonth %>% as.integer(),
             week      = lubridate::week(index) %>% as.integer(),
             week.iso  = lubridate::isoweek(index) %>% as.integer(),
             week2     = as.integer(week %% 2),


### PR DESCRIPTION
The `lubridate::as_date()` function relies on the user's timezone, which causes some issues with retrieving the week of the month at the beginning or end of a month when getting the time series signature. Switching to `lubridate::as_datetime()` solves this issue and returns the expected week of the month. Reprex included below. 

``` r
Sys.setenv(TZ = 'America/Chicago')
stringi::stri_datetime_fields(lubridate::as_date('2022-11-01'))
#>   Year Month Day Hour Minute Second Millisecond WeekOfYear WeekOfMonth
#> 1 2022    10  31   19      0      0           0         45           6
#>   DayOfYear DayOfWeek Hour12 AmPm Era
#> 1       304         2      7    2   2
stringi::stri_datetime_fields(lubridate::as_datetime('2022-11-01'))
#>   Year Month Day Hour Minute Second Millisecond WeekOfYear WeekOfMonth
#> 1 2022    11   1    0      0      0           0         45           1
#>   DayOfYear DayOfWeek Hour12 AmPm Era
#> 1       305         3      0    1   2
```

<sup>Created on 2023-05-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>