### PR TITLE
Use minty instead #164

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     lubridate (>= 1.6.0),
     padr (>= 0.5.2),
     purrr (>= 0.2.2),
-    readr (>= 1.3.0),
+    minty,
     stringi (>= 1.4.6),
     tibble (>= 3.0.3),
     tidyr (>= 1.1.0),

--- a/R/coersion-tk_tbl.R
+++ b/R/coersion-tk_tbl.R
@@ -106,7 +106,7 @@ tk_tbl.data.frame <- function(data, preserve_index = TRUE, rename_index = "index
                 tibble::as_tibble(...)
 
             if (any(vapply(ret, is.character, logical(1)))) {
-                ret <- suppressMessages(readr::type_convert(ret))
+                ret <- minty::type_convert(ret)
             }
 
         } else {
@@ -164,7 +164,7 @@ tk_tbl.zoo <- function(data, preserve_index = TRUE, rename_index = "index", time
             if (!is.null(rename_index)) colnames(ret)[[1]] <- rename_index
 
             if (any(vapply(ret, is.character, logical(1)))) {
-                ret <- suppressMessages(readr::type_convert(ret))
+                ret <- minty::type_convert(ret)
             }
 
         } else {


### PR DESCRIPTION
By switching to `minty`, the number of (recursive) dependencies reduces to 121 (was 129). Notably, one doesn't need to compile `vroom`. (but guarantees that `type_convert` behaves the same as the current readr parsing behaviors since 2021, i.e. like `vroom`).

``` r
tools::package_dependencies(c("recipes", "rsample", "dplyr", "ggplot2", "forcats", "stringr", "plotly", "lubridate", "padr", "purrr", "stringi", "tibble", "tidyr", "xts", "zoo", "rlang", "tidyselect", "slider", "anytime", "timeDate", "forecast", "tsfeatures", "hms", "generics", "minty"), recursive = TRUE) |> unlist() |> unique()
#>   [1] "dplyr"         "cli"           "clock"         "ellipsis"     
#>   [5] "generics"      "glue"          "gower"         "hardhat"      
#>   [9] "ipred"         "lifecycle"     "lubridate"     "magrittr"     
#>  [13] "Matrix"        "purrr"         "rlang"         "stats"        
#>  [17] "tibble"        "tidyr"         "tidyselect"    "timeDate"     
#>  [21] "utils"         "vctrs"         "withr"         "tzdb"         
#>  [25] "cpp11"         "methods"       "pillar"        "R6"           
#>  [29] "rpart"         "MASS"          "survival"      "nnet"         
#>  [33] "class"         "prodlim"       "timechange"    "grDevices"    
#>  [37] "graphics"      "grid"          "lattice"       "fansi"        
#>  [41] "pkgconfig"     "stringr"       "utf8"          "Rcpp"         
#>  [45] "data.table"    "diagram"       "KernSmooth"    "lava"         
#>  [49] "stringi"       "splines"       "shape"         "future.apply" 
#>  [53] "numDeriv"      "progressr"     "SQUAREM"       "tools"        
#>  [57] "future"        "globals"       "parallel"      "digest"       
#>  [61] "listenv"       "parallelly"    "codetools"     "furrr"        
#>  [65] "slider"        "warp"          "gtable"        "isoband"      
#>  [69] "mgcv"          "scales"        "nlme"          "farver"       
#>  [73] "labeling"      "munsell"       "RColorBrewer"  "viridisLite"  
#>  [77] "colorspace"    "ggplot2"       "httr"          "jsonlite"     
#>  [81] "base64enc"     "htmltools"     "htmlwidgets"   "lazyeval"     
#>  [85] "crosstalk"     "promises"      "fastmap"       "knitr"        
#>  [89] "rmarkdown"     "yaml"          "curl"          "mime"         
#>  [93] "openssl"       "later"         "evaluate"      "highr"        
#>  [97] "xfun"          "askpass"       "bslib"         "fontawesome"  
#> [101] "jquerylib"     "tinytex"       "sys"           "cachem"       
#> [105] "memoise"       "sass"          "fs"            "rappdirs"     
#> [109] "zoo"           "BH"            "fracdiff"      "lmtest"       
#> [113] "tseries"       "urca"          "RcppArmadillo" "quadprog"     
#> [117] "quantmod"      "xts"           "TTR"           "forecast"     
#> [121] "RcppRoll"
```

``` r

tools::package_dependencies(c("recipes", "rsample", "dplyr", "ggplot2", "forcats", "stringr", "plotly", "lubridate", "padr", "purrr", "stringi", "tibble", "tidyr", "xts", "zoo", "rlang", "tidyselect", "slider", "anytime", "timeDate", "forecast", "tsfeatures", "hms", "generics", "readr"), recursive = TRUE) |> unlist() |> unique()
#>   [1] "dplyr"         "cli"           "clock"         "ellipsis"     
#>   [5] "generics"      "glue"          "gower"         "hardhat"      
#>   [9] "ipred"         "lifecycle"     "lubridate"     "magrittr"     
#>  [13] "Matrix"        "purrr"         "rlang"         "stats"        
#>  [17] "tibble"        "tidyr"         "tidyselect"    "timeDate"     
#>  [21] "utils"         "vctrs"         "withr"         "tzdb"         
#>  [25] "cpp11"         "methods"       "pillar"        "R6"           
#>  [29] "rpart"         "MASS"          "survival"      "nnet"         
#>  [33] "class"         "prodlim"       "timechange"    "grDevices"    
#>  [37] "graphics"      "grid"          "lattice"       "fansi"        
#>  [41] "pkgconfig"     "stringr"       "utf8"          "Rcpp"         
#>  [45] "data.table"    "diagram"       "KernSmooth"    "lava"         
#>  [49] "stringi"       "splines"       "shape"         "future.apply" 
#>  [53] "numDeriv"      "progressr"     "SQUAREM"       "tools"        
#>  [57] "future"        "globals"       "parallel"      "digest"       
#>  [61] "listenv"       "parallelly"    "codetools"     "furrr"        
#>  [65] "slider"        "warp"          "gtable"        "isoband"      
#>  [69] "mgcv"          "scales"        "nlme"          "farver"       
#>  [73] "labeling"      "munsell"       "RColorBrewer"  "viridisLite"  
#>  [77] "colorspace"    "ggplot2"       "httr"          "jsonlite"     
#>  [81] "base64enc"     "htmltools"     "htmlwidgets"   "lazyeval"     
#>  [85] "crosstalk"     "promises"      "fastmap"       "knitr"        
#>  [89] "rmarkdown"     "yaml"          "curl"          "mime"         
#>  [93] "openssl"       "later"         "evaluate"      "highr"        
#>  [97] "xfun"          "askpass"       "bslib"         "fontawesome"  
#> [101] "jquerylib"     "tinytex"       "sys"           "cachem"       
#> [105] "memoise"       "sass"          "fs"            "rappdirs"     
#> [109] "zoo"           "BH"            "fracdiff"      "lmtest"       
#> [113] "tseries"       "urca"          "RcppArmadillo" "quadprog"     
#> [117] "quantmod"      "xts"           "TTR"           "forecast"     
#> [121] "RcppRoll"      "clipr"         "crayon"        "hms"          
#> [125] "vroom"         "bit64"         "progress"      "bit"          
#> [129] "prettyunits"
```

<sup>Created on 2024-06-11 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
